### PR TITLE
issue #43: fixes for WriteAllText with and without encoding

### DIFF
--- a/ChinhDo.Transactions.FileManager/TxFileManager.cs
+++ b/ChinhDo.Transactions.FileManager/TxFileManager.cs
@@ -212,7 +212,14 @@ namespace ChinhDo.Transactions
 
         public void WriteAllText(string path, string contents)
         {
-            WriteAllText(path, contents, Encoding.Default);
+            if (IsInTransaction())
+            {
+                EnlistOperation(new WriteAllTextOperation(GetTempPath(), path, contents, null));
+            }
+            else
+            {
+                File.WriteAllText(path, contents);
+            }
         }
 
         public void WriteAllText(string path, string contents, Encoding encoding)
@@ -223,7 +230,7 @@ namespace ChinhDo.Transactions
             }
             else
             {
-                File.WriteAllText(path, contents);
+                File.WriteAllText(path, contents, encoding);
             }
         }
 

--- a/ChinhDo.Transactions.FileManagerTest/FileManagerTests.cs
+++ b/ChinhDo.Transactions.FileManagerTest/FileManagerTests.cs
@@ -441,6 +441,38 @@ namespace ChinhDo.Transactions.FileManagerTest
             Assert.Equal(contents1, File.ReadAllText(f1));
         }
 
+        [Fact]
+        public void CanWriteAllTextWithEncoding()
+        {
+            string f1 = GetTempPathName();
+            const string contents = "abcdef";
+            File.WriteAllText(f1, "123", Encoding.UTF8);
+
+            using (TransactionScope scope1 = new TransactionScope())
+            {
+                _target.WriteAllText(f1, contents, Encoding.UTF8);
+                scope1.Complete();
+            }
+
+            Assert.Equal(contents, File.ReadAllText(f1));
+        }
+
+        [Fact]
+        public void CanWriteAllTextWithEncodingAndRollback()
+        {
+            string f1 = GetTempPathName();
+            const string contents1 = "123";
+            const string contents2 = "abcdef";
+            File.WriteAllText(f1, contents1, Encoding.UTF8);
+
+            using (TransactionScope scope1 = new TransactionScope())
+            {
+                _target.WriteAllText(f1, contents2, Encoding.UTF8);
+            }
+
+            Assert.Equal(contents1, File.ReadAllText(f1));
+        }
+
         #endregion
 
         #region Transaction Support


### PR DESCRIPTION
WriteAllText without encoding: use the .Net overload without encoding.
WriteAllText with encoding: pass on the encoding to .Net when not in a transaction.